### PR TITLE
allows any omxplayer args, fixes pause/play bug

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -119,6 +119,10 @@ var omxdirector = function () {
     if (settings.osd == false){
       args.push('--no-osd')
     }
+    
+    if (settings.args) {
+      args = args.concat(settings.args);
+    }
 
     if (typeof videos === 'string') {
       videos = [videos];

--- a/lib/main.js
+++ b/lib/main.js
@@ -258,6 +258,7 @@ var omxdirector = function () {
       /* ignore, no omxProcess to stop */
       return false;
     }
+    paused = false;
     loopHelper = null;
     sendAction('quit');
     handleQuitTimeout(omxProcess, 250);


### PR DESCRIPTION
Unless I glossed over it, there is no way to access the other omxplayer flags when opening a new file. I need to be able to set the window, etc. Also, this fixes a bug where if you pause a video, then stop it, when you play another video, the pause trigger was still set to true, breaking the next pause you attempt.