### PR TITLE
Adding 'osd' as an option

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -31,7 +31,9 @@ var omxdirector = function() {
     if (commands[action] && omxProcess) {
       try {
         omxProcess.stdin.write(commands[action], function(err) {
-          console.log(err);
+			if(err){
+				console.log(err);
+			}
         });
       } catch (err) {
         console.log(err);
@@ -72,6 +74,10 @@ var omxdirector = function() {
       if (nativeLoop) {
         args.push('-L');
       }
+    }
+
+   if (settings.osd === false) {
+        args.push('--no-osd');
     }
 
     if (typeof videos === 'string') {


### PR DESCRIPTION
For removing omxplayer's on-screen display. It appends "--no-osd" to omxplayer command line.

You can combine this option with existing options, e.g.
omx.play(['video.mp4', 'anothervideo.mp4', 'foo.mp4'], {loop: true, osd: false});